### PR TITLE
Add filters to have custom columns on CSV export

### DIFF
--- a/src/SettingsPage.php
+++ b/src/SettingsPage.php
@@ -174,6 +174,12 @@ class SettingsPage extends Tab {
 
 			/** Get selected columns. */
 			$columns = get_option( 'uewm_columns' );
+
+            /** Add custom columns */
+            $custom_columns = apply_filters('uewm_custom_columns', array());
+            $columns = array_merge($columns, $custom_columns);
+            $allowlist = array_merge($allowlist, $custom_columns);
+
 			$columns = $columns ? $columns : $allowlist; /** Empty = All. */
 
 			/** Filter columns. */

--- a/src/Users.php
+++ b/src/Users.php
@@ -98,6 +98,17 @@ class Users {
 		foreach ( $meta_records as $record ) {
 			$user_rows[ $record->user_id ][ $record->meta_key ] = $record->meta_value;
 		}
+
+        /** Add custom info */
+        $custom_columns = apply_filters('uewm_custom_columns', array());
+        if( ! empty( $custom_columns ) ) {
+            foreach ( $user_records as $record ) {
+                foreach ($custom_columns as $key => $column_name) {
+                    $user_rows[ $record->ID ][ $column_name ] = apply_filters('uewm_custom_column_value_' . $column_name, '', $record->ID);
+                }
+            }
+        }
+
 		return $user_rows;
 	}
 


### PR DESCRIPTION
Hi @loureirorg,

can you consider merging this PR to the next plugin version?

I've added two filters:
**uewm_custom_columns**
**uewm_custom_column_value_xxxxxxxx**

Then we can hook them to add custom values to the CSV export for each user.

I personally use them to have data that it's not as user meta. For instance, I use the WooCommerce Subscriptions plugin and this allows me to have a column with the subscription status for each user. Sth like this:


```
add_filter('uewm_custom_columns', function( $columns ) {
    $columns[] = 'subscription-status';

    return $columns;
});

add_filter('uewm_custom_column_value_subscription-status', function( $value, $user_id ) {
    if ( wcs_user_has_subscription( $user_id, '', 'active' ) ) {
        return 'active';
    }

    return '-';
}, 10, 2);

```

 